### PR TITLE
add name to cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "tz"
 maintainer       "James Harton"
 maintainer_email "james@sociable.co.nz"
 license          "Apache 2.0"


### PR DESCRIPTION
Required by Chef 12.0.*
Otherwise raises cookbook error.
